### PR TITLE
Closes #97: Fix selected category button

### DIFF
--- a/src/main/java/com/example/a1project/controllers/MainScreenController.java
+++ b/src/main/java/com/example/a1project/controllers/MainScreenController.java
@@ -14,8 +14,16 @@ import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.GridPane;
+
+import javafx.scene.control.Toggle;
+
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
 
 public class MainScreenController extends SceneController implements Initializable {
 	

--- a/src/main/java/com/example/a1project/controllers/MainScreenController.java
+++ b/src/main/java/com/example/a1project/controllers/MainScreenController.java
@@ -129,6 +129,9 @@ public class MainScreenController extends SceneController implements Initializab
 			break;
 		case "All":
 			setCategoryVisible("All");
+			workToggle.getStyleClass().remove("selected-toggle");
+			schoolToggle.getStyleClass().remove("selected-toggle");
+			homeToggle.getStyleClass().remove("selected-toggle");
 			break;
 		default:
 			break;


### PR DESCRIPTION
Closes #97. If a currently selected category button is pressed again, it's styling will change to be that of being unselected again to signal to the user that there are currently no category filters on the list of tasks.

Pressing Work once:
![image](https://user-images.githubusercontent.com/79787985/196309748-34110ba0-452d-4641-82f9-3ce8971245b4.png)

Pressing Work again:
![image](https://user-images.githubusercontent.com/79787985/196309768-3362a428-3042-4503-9720-e186b7dc2125.png)
